### PR TITLE
Add Node Management Dialog

### DIFF
--- a/app/src/main/java/com/offmind/runtimeshaders/composables/ui/NodeCanvas.kt
+++ b/app/src/main/java/com/offmind/runtimeshaders/composables/ui/NodeCanvas.kt
@@ -3,7 +3,9 @@ package com.offmind.runtimeshaders.composables.ui
 import android.content.res.Configuration
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -61,7 +63,8 @@ fun NodeCanvas(
     nodes: List<NodeData> = emptyList(),
     connections: List<NodeConnection> = emptyList(),
     vm: NodeEditorViewModel? = null,
-    onNodePositionChange: (Int, Offset) -> Unit = { _, _ -> }
+    onNodePositionChange: (Int, Offset) -> Unit = { _, _ -> },
+    onDoubleTap: (Offset) -> Unit = {}
 ) {
     var canvasOffset by remember { mutableStateOf(Offset.Zero) }
 
@@ -73,6 +76,11 @@ fun NodeCanvas(
         modifier = modifier
             .background(color = Color.DarkGray)
             .pointerInput(Unit) {
+                detectTapGestures (
+                    onDoubleTap = { offset ->
+                        onDoubleTap(offset)
+                    },
+                )
                 detectDragGestures { change, dragAmount ->
                     canvasOffset += dragAmount
                     change.consume()

--- a/app/src/main/java/com/offmind/runtimeshaders/screens/editor/NodeEditScreen.kt
+++ b/app/src/main/java/com/offmind/runtimeshaders/screens/editor/NodeEditScreen.kt
@@ -2,6 +2,8 @@ package com.offmind.runtimeshaders.screens.editor
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -14,16 +16,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.offmind.runtimeshaders.composables.ShadedBox
 import com.offmind.runtimeshaders.composables.ui.NodeCanvas
+import com.offmind.runtimeshaders.screens.editor.dialog.DialogState
+import com.offmind.runtimeshaders.screens.editor.dialog.manage_node.ManageNodeBottomShitDialog
 import com.offmind.runtimeshaders.screens.editor.model.NodeDataType
 import com.offmind.runtimeshaders.shaders.Shader
 import com.offmind.runtimeshaders.shaders.toVec4Type
@@ -34,6 +43,7 @@ fun NodeEditScreen(paddingValues: PaddingValues) {
 
     val vm = koinViewModel<NodeEditorViewModel>()
     val state = vm.state.collectAsState()
+    var dialogState by remember { mutableStateOf(DialogState(false))}
 
     val colorNode = state.value.nodes.firstOrNull { it.nodeDataType is NodeDataType.ColorNode }
 
@@ -57,9 +67,13 @@ fun NodeEditScreen(paddingValues: PaddingValues) {
                 nodes = state.value.nodes,
                 vm = vm,
                 connections = state.value.connections,
-            ) { nodeId, newPosition ->
-                vm.onNodePositionChange(nodeId, newPosition)
-            }
+                onNodePositionChange = { id, position ->
+                    vm.onNodePositionChange(id, position)
+                },
+                onDoubleTap = {
+                    dialogState = DialogState(true)
+                }
+            )
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -73,6 +87,19 @@ fun NodeEditScreen(paddingValues: PaddingValues) {
                     )
             )
         }
+    }
+
+    if (dialogState.showManageNodeDialog) {
+        ManageNodeBottomShitDialog(
+            modifier = Modifier.fillMaxWidth(),
+            onDismissRequest = {
+                dialogState = DialogState()
+            },
+            onAddNodeClicked = {
+                vm.addNode(it)
+                dialogState = DialogState()
+            }
+        )
     }
 
 }

--- a/app/src/main/java/com/offmind/runtimeshaders/screens/editor/NodeEditorViewModel.kt
+++ b/app/src/main/java/com/offmind/runtimeshaders/screens/editor/NodeEditorViewModel.kt
@@ -1,20 +1,18 @@
 package com.offmind.runtimeshaders.screens.editor
 
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.snapshots.SnapshotMutableState
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
-import com.offmind.runtimeshaders.screens.editor.model.AGVector3
+import com.offmind.runtimeshaders.screens.editor.dialog.manage_node.AddUINodeItem
 import com.offmind.runtimeshaders.screens.editor.model.NodeConnection
 import com.offmind.runtimeshaders.screens.editor.model.NodeData
 import com.offmind.runtimeshaders.screens.editor.model.NodeDataType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import org.w3c.dom.Node
 
 class NodeEditorViewModel : ViewModel() {
 
@@ -75,6 +73,20 @@ class NodeEditorViewModel : ViewModel() {
                 }
             }.toMutableStateList()
             state.copy(nodes = updatedNodes)
+        }
+    }
+
+    fun addNode(addUiNodeItem: AddUINodeItem) {
+        _state.update { state ->
+            val newNode = NodeData(
+                id = state.nodes.size,
+                name = addUiNodeItem.title,
+                position = Offset(10f, 50f), //todo decide position of new node
+                nodeDataType = addUiNodeItem.nodeData
+            )
+            val updatedNodes = state.nodes.toMutableList()
+            updatedNodes.add(newNode)
+            state.copy(nodes = updatedNodes.toMutableStateList())
         }
     }
 

--- a/app/src/main/java/com/offmind/runtimeshaders/screens/editor/dialog/DialogState.kt
+++ b/app/src/main/java/com/offmind/runtimeshaders/screens/editor/dialog/DialogState.kt
@@ -1,0 +1,5 @@
+package com.offmind.runtimeshaders.screens.editor.dialog
+
+data class DialogState(
+    val showManageNodeDialog: Boolean = false,
+)

--- a/app/src/main/java/com/offmind/runtimeshaders/screens/editor/dialog/manage_node/AddUINodeItem.kt
+++ b/app/src/main/java/com/offmind/runtimeshaders/screens/editor/dialog/manage_node/AddUINodeItem.kt
@@ -1,0 +1,56 @@
+package com.offmind.runtimeshaders.screens.editor.dialog.manage_node
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import com.offmind.runtimeshaders.screens.editor.model.AGVector3
+import com.offmind.runtimeshaders.screens.editor.model.NodeDataType
+
+sealed class AddUINodeItem {
+    abstract val title: String
+    abstract val nodeData: NodeDataType
+
+    data object ColorNode : AddUINodeItem() {
+        override val title: String
+            get() = "Color Node"
+        override val nodeData: NodeDataType
+            get() = NodeDataType.ColorNode(Color.White)
+    }
+
+    data object UVNode : AddUINodeItem() {
+        override val title: String
+            get() = "UV Node"
+        override val nodeData: NodeDataType
+            get() = NodeDataType.UVNode(Offset(0f, 0f))
+    }
+
+    data object LengthNode : AddUINodeItem() {
+        override val title: String
+            get() = "Length Node"
+        override val nodeData: NodeDataType
+            get() = NodeDataType.LengthNode(0f)
+    }
+
+    data object InputNode : AddUINodeItem() {
+        override val title: String
+            get() = "Input Node"
+        override val nodeData: NodeDataType
+            get() = NodeDataType.InputNode(AGVector3(0f, 0f, 0f))
+    }
+
+    data object OutputNode : AddUINodeItem() {
+        override val title: String
+            get() = "Output Node"
+        override val nodeData: NodeDataType
+            get() = NodeDataType.OutputNode(Color.White)
+    }
+
+    companion object {
+        val items = listOf(
+            ColorNode,
+            UVNode,
+            LengthNode,
+            InputNode,
+            OutputNode
+        )
+    }
+}

--- a/app/src/main/java/com/offmind/runtimeshaders/screens/editor/dialog/manage_node/ManageNodeBottomShitDialog.kt
+++ b/app/src/main/java/com/offmind/runtimeshaders/screens/editor/dialog/manage_node/ManageNodeBottomShitDialog.kt
@@ -1,0 +1,68 @@
+package com.offmind.runtimeshaders.screens.editor.dialog.manage_node
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.offmind.runtimeshaders.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ManageNodeBottomShitDialog(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    onAddNodeClicked: (AddUINodeItem) -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = rememberModalBottomSheetState(),
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+    ) {
+        Text(modifier = Modifier.padding(10.dp),text = stringResource(R.string.add_new_node), style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(16.dp))
+        LazyColumn(Modifier.fillMaxWidth()) {
+            items(AddUINodeItem.items) { item ->
+                AddNodeItem(nodeUiType = item, onItemClick = onAddNodeClicked)
+            }
+        }
+    }
+}
+
+@Composable
+fun AddNodeItem(
+    modifier: Modifier = Modifier,
+    nodeUiType: AddUINodeItem,
+    onItemClick: (AddUINodeItem) -> Unit
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .clickable { onItemClick(nodeUiType) }
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(nodeUiType.title, style = MaterialTheme.typography.bodyMedium)
+        Icon(imageVector = Icons.Default.Add, contentDescription = "Add new node")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">RuntimeShaders</string>
+
+<!--    Node manage dialog-->
+    <string name="add_new_node">Add new node</string>
+    <string name="add_color_node">Add Color Node</string>
 </resources>


### PR DESCRIPTION
This commit introduces a new dialog for managing nodes in the editor.
- Implemented `ManageNodeBottomShitDialog` composable for adding new nodes.
- Added `AddUINodeItem` to represent different node types.
- Added double-tap gesture to `NodeCanvas` to open the management dialog.
- Updated `NodeEditorViewModel` to support adding nodes.
- Added new string resources for the management dialog.
- Created a `DialogState` data class to manage the visibility of the dialog.